### PR TITLE
fix(Nng.java): 将条件检查从props.contains更改为props.containsKey

### DIFF
--- a/src/main/java/io/sisu/nng/Nng.java
+++ b/src/main/java/io/sisu/nng/Nng.java
@@ -49,7 +49,7 @@ public class Nng {
             System.setProperty("jna.debug_load",
                     System.getenv().getOrDefault("JNA_DEBUG_LOAD", ""));
         }
-        if (!props.contains("jna.library.path")) {
+        if (!props.containsKey("jna.library.path")) {
             System.setProperty("jna.library.path",
                     System.getenv().getOrDefault("JNA_LIBRARY_PATH", ""));
         }


### PR DESCRIPTION
在原来的代码中，使用了contains方法来检查属性是否存在于props中。这个更改将条件检查改为containsKey方法，以确保准确检查属性是否存在。